### PR TITLE
Make full-page-image-view work with next/image

### DIFF
--- a/src/common/full-page-image-view.tsx
+++ b/src/common/full-page-image-view.tsx
@@ -1,4 +1,5 @@
 import { clerkClient } from "@clerk/nextjs/server";
+import Image from "next/image";
 import { Button } from "~/components/ui/button";
 import { deleteImage, getImage } from "~/server/queries";
 
@@ -12,8 +13,14 @@ export async function FullPageImageView(props: { photoId: string }) {
 
   return (
     <div className="flex h-full w-screen min-w-0 items-center justify-center text-white">
-      <div className="flex-shrink flex-grow">
-        <img src={image.url} className="object-contain" alt={image.name} />
+      <div className="relative size-full">
+        <Image
+          src={image.url}
+          fill
+          priority
+          className="object-contain"
+          alt={image.name}
+        />
       </div>
       <div className="flex h-full w-56 flex-shrink-0 flex-col border-l">
         <div className="border-b p-2 text-center text-xl">{image.name}</div>


### PR DESCRIPTION
Here is a way to use the Image component from next/image with images of unknown sizes.

As mentioned in the [docs](https://nextjs.org/docs/app/api-reference/components/image#fill), images with `fill=true` is by default set to `position:absolute`, so the parent element needs to have either `relative`, `absolute` or `fixed` positioning (since elements with `position:static` are ignored by absolutely positioned elements).

If you are interested, this is the styling that Next applies to the image:
```
element.style {
    position: absolute;
    height: 100%;
    width: 100%;
    left: 0;
    top: 0;
    right: 0;
    bottom: 0;
    color: transparent;
}
```

The simplest solution I found was to give the parent div  `position:relative` and give it 100% width and height with the `size-full` tailwind class.

One subtle difference between my solution and the existing one is that the parent div now covers the "empty" area outside the image (if the image ratio is not perfect for the screen size, that is), whereas the in current implementation the div will be the same size as the image. There is no visual difference, you only see it when inspecting the elements, or if you give the div a background color. 
(I also gave the image `priority=true` to get rid of console warnings. This will [preload](https://nextjs.org/docs/app/api-reference/components/image#fill) the images.) 

PS:
The tutorial was really nice 👍🏻 